### PR TITLE
Revert EEG MADE metadata to Preprocessing instead of Preproc

### DIFF
--- a/HBCD_Data_Dictionaries/eeg_made_task-FACE_acq-eeg_preprocessingReport.json
+++ b/HBCD_Data_Dictionaries/eeg_made_task-FACE_acq-eeg_preprocessingReport.json
@@ -1,6 +1,6 @@
 {
     "MeasurementToolMetadata": {
-        "Description": "MADE Preproc Report for FACE task",
+        "Description": "MADE Preprocessing Report for FACE task",
         "TermURL": "https://hbcd-made.readthedocs.io/en/latest/expected_outputs.html#eeg-made-preprocessing-report-csv",
         "Name": "MADE Preprocessing Report for FACE task",
         "Category": [

--- a/HBCD_Data_Dictionaries/eeg_made_task-FACE_acq-eeg_preprocessingReport.json
+++ b/HBCD_Data_Dictionaries/eeg_made_task-FACE_acq-eeg_preprocessingReport.json
@@ -2,7 +2,7 @@
     "MeasurementToolMetadata": {
         "Description": "MADE Preproc Report for FACE task",
         "TermURL": "https://hbcd-made.readthedocs.io/en/latest/expected_outputs.html#eeg-made-preprocessing-report-csv",
-        "Name": "MADE Preproc Report for FACE task",
+        "Name": "MADE Preprocessing Report for FACE task",
         "Category": [
             "EEG"
         ]

--- a/HBCD_Data_Dictionaries/eeg_made_task-MMN_acq-eeg_preprocessingReport.json
+++ b/HBCD_Data_Dictionaries/eeg_made_task-MMN_acq-eeg_preprocessingReport.json
@@ -1,6 +1,6 @@
 {
     "MeasurementToolMetadata": {
-        "Description": "MADE Preproc Report for MMN task",
+        "Description": "MADE Preprocessing Report for MMN task",
         "TermURL": "https://hbcd-made.readthedocs.io/en/latest/expected_outputs.html#eeg-made-preprocessing-report-csv",
         "Name": "MADE Preprocessing Report for MMN task",
         "Category": [

--- a/HBCD_Data_Dictionaries/eeg_made_task-MMN_acq-eeg_preprocessingReport.json
+++ b/HBCD_Data_Dictionaries/eeg_made_task-MMN_acq-eeg_preprocessingReport.json
@@ -2,7 +2,7 @@
     "MeasurementToolMetadata": {
         "Description": "MADE Preproc Report for MMN task",
         "TermURL": "https://hbcd-made.readthedocs.io/en/latest/expected_outputs.html#eeg-made-preprocessing-report-csv",
-        "Name": "MADE Preproc Report for MMN task",
+        "Name": "MADE Preprocessing Report for MMN task",
         "Category": [
             "EEG"
         ]

--- a/HBCD_Data_Dictionaries/eeg_made_task-RS_acq-eeg_preprocessingReport.json
+++ b/HBCD_Data_Dictionaries/eeg_made_task-RS_acq-eeg_preprocessingReport.json
@@ -2,7 +2,7 @@
     "MeasurementToolMetadata": {
         "Description": "MADE Preproc Report for RS task",
         "TermURL": "https://hbcd-made.readthedocs.io/en/latest/expected_outputs.html#eeg-made-preprocessing-report-csv",
-        "Name": "MADE Preproc Report for RS task",
+        "Name": "MADE Preprocessing Report for RS task",
         "Category": [
             "EEG"
         ]

--- a/HBCD_Data_Dictionaries/eeg_made_task-RS_acq-eeg_preprocessingReport.json
+++ b/HBCD_Data_Dictionaries/eeg_made_task-RS_acq-eeg_preprocessingReport.json
@@ -1,6 +1,6 @@
 {
     "MeasurementToolMetadata": {
-        "Description": "MADE Preproc Report for RS task",
+        "Description": "MADE Preprocessing Report for RS task",
         "TermURL": "https://hbcd-made.readthedocs.io/en/latest/expected_outputs.html#eeg-made-preprocessing-report-csv",
         "Name": "MADE Preprocessing Report for RS task",
         "Category": [

--- a/HBCD_Data_Dictionaries/eeg_made_task-VEP_acq-eeg_preprocessingReport.json
+++ b/HBCD_Data_Dictionaries/eeg_made_task-VEP_acq-eeg_preprocessingReport.json
@@ -1,6 +1,6 @@
 {
     "MeasurementToolMetadata": {
-        "Description": "MADE Preproc Report for VEP task",
+        "Description": "MADE Preprocessing Report for VEP task",
         "TermURL": "https://hbcd-made.readthedocs.io/en/latest/expected_outputs.html#eeg-made-preprocessing-report-csv",
         "Name": "MADE Preprocessing Report for VEP task",
         "Category": [

--- a/HBCD_Data_Dictionaries/eeg_made_task-VEP_acq-eeg_preprocessingReport.json
+++ b/HBCD_Data_Dictionaries/eeg_made_task-VEP_acq-eeg_preprocessingReport.json
@@ -2,7 +2,7 @@
     "MeasurementToolMetadata": {
         "Description": "MADE Preproc Report for VEP task",
         "TermURL": "https://hbcd-made.readthedocs.io/en/latest/expected_outputs.html#eeg-made-preprocessing-report-csv",
-        "Name": "MADE Preproc Report for VEP task",
+        "Name": "MADE Preprocessing Report for VEP task",
         "Category": [
             "EEG"
         ]


### PR DESCRIPTION
Revert changes wrong made for the MADE preproc files in the metadata section.